### PR TITLE
Use centered text for app boxes

### DIFF
--- a/src/components/CytoscapeGraph/Layout/GroupCompoundLayout.ts
+++ b/src/components/CytoscapeGraph/Layout/GroupCompoundLayout.ts
@@ -222,13 +222,6 @@ export default class GroupCompoundLayout {
         // Discard the saved values
         parent.removeScratch(CHILDREN_KEY);
         parent.removeScratch(STYLES_KEY);
-
-        // This will fix the label width issue when the layout changes, but it
-        // doesn't work well when the node is selected or hovered. It also prevents
-        // the label from being properly aligned when the graph is first loaded
-        /* parent.style('text-margin-x', (ele: any) => {
-                return '-' + (+ele.width() + +ele.style('padding').slice(0,-2) * 2 )+ "px";
-        }); */
       });
       // (4.a) Add the real edges, we already added the children nodes.
       this.cy.add(

--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -219,15 +219,15 @@ export class GraphStyles {
         } else {
           const contentArray: string[] = [];
           if ((isMultiNamespace || isOutside) && !(isServiceEntry || nodeType === NodeType.UNKNOWN)) {
-            contentArray.push('(' + namespace + ')');
+            contentArray.push(`(${namespace})`);
           }
           switch (nodeType) {
             case NodeType.APP:
               if (cyGlobal.graphType === GraphType.APP || isGroup || version === 'unknown') {
                 contentArray.unshift(app);
               } else {
+                contentArray.unshift(version);
                 contentArray.unshift(app);
-                contentArray.push(version);
               }
               break;
             case NodeType.SERVICE:
@@ -349,11 +349,7 @@ export class GraphStyles {
         selector: `$node > node, node.${COMPOUND_PARENT_NODE_CLASS}`,
         css: {
           'text-valign': 'top',
-          'text-halign': 'right',
-          'text-margin-x': (ele: any) => {
-            return '-' + (+ele.width() + +ele.style('padding').slice(0, -2) * 2) + 'px';
-          },
-          'text-margin-y': '-2px',
+          'text-halign': 'center',
           'background-color': NodeColorFillBox
         }
       },


### PR DESCRIPTION
@mwringe , I'm impressed with your ability to get the "aligned-left" app-box labeling close to working.  I did not have success getting past that final issue.  I could keep trying but for app-box labels it seems difficult to generate and apply the proper x-offsets with consistent results.  So, I propose we avoid the issue and use top-center labels for app boxes..  Cy does a good job with this, it maximizes space, is easy to see, and is consistent with the centered labels on every other node and edge.

This PR does that, you can give it a try.  It also makes one more change, I think we should consistently position the (namespace) at the bottom of any stacked label.  This PR applies that change to external versioned app nodes.

![image](https://user-images.githubusercontent.com/2104052/57108796-d0fac100-6d01-11e9-9b6f-1f44a6c63792.png)
