### PR TITLE
 KIALI-2768 Couple more of fixes

### DIFF
--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -351,7 +351,10 @@ export class GraphStyles {
           'text-valign': 'top',
           'text-halign': 'right',
           'text-margin-x': (ele: any) => {
-            return '-' + (+ele.width() + +ele.style('padding').slice(0, -2) * 2) + 'px';
+            // numericStyle returns the size in the "preferred" units
+            // numericStyleUnits return the "preferred" unit
+            // Preferred unit for elements is model dimensions (px) (the same unit used for ele.width)
+            return '-' + (ele.width() + ele.numericStyle('padding') * 2) + ele.numericStyleUnits('padding');
           },
           'text-margin-y': '-2px',
           'background-color': NodeColorFillBox

--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -226,8 +226,8 @@ export class GraphStyles {
               if (cyGlobal.graphType === GraphType.APP || isGroup || version === 'unknown') {
                 contentArray.unshift(app);
               } else {
+                contentArray.unshift(version);
                 contentArray.unshift(app);
-                contentArray.push(version);
               }
               break;
             case NodeType.SERVICE:


### PR DESCRIPTION

- Ensures the namespace is always at bottom 
- Let cytoscape decide the units and avoid parsing the css